### PR TITLE
Adds client side channel creation (resolves #11)

### DIFF
--- a/ios/sound-send/sound-send/Info.plist
+++ b/ios/sound-send/sound-send/Info.plist
@@ -34,5 +34,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key><true/>
+    </dict>
 </dict>
 </plist>

--- a/ios/sound-send/sound-send/ViewController.swift
+++ b/ios/sound-send/sound-send/ViewController.swift
@@ -9,17 +9,85 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    //the base url, change it when we have one i guess?
+    let baseurl = "http://www.soundsend.com"
+    let createchannelpath = "/channelmanager/createchannel/"
+    let channelCreateSuccessStatusCode = 201
+    let channelCreateFailureStatusCode = 400
+    
+    func generateCreateChannelURL(channelname: String) -> String {
+        let uuid = UIDevice.current.identifierForVendor!.uuidString
+        return baseurl+createchannelpath+channelname+"/"+uuid
+    }
+    
+    //sends a create channel get request with an input channel name
+    func createChannel(channelname: String) {
+        let url = NSURL(string: generateCreateChannelURL(channelname: channelname))
+        
+        let task = URLSession.shared.dataTask(with: url! as URL) {(data, response, error) in
+            self.handleCreateChannelResponse(data: data, response: response, error: error)
+        }
+        
+        task.resume()
+    }
+    
+    //creates an alert with the title "Error" and an input string
+    func showAlert(alertstring: String) {
+        let alertController = UIAlertController(title: "Error", message: alertstring, preferredStyle: UIAlertControllerStyle.alert)
+        let okAction = UIAlertAction(title: "OK", style: UIAlertActionStyle.default) { (result : UIAlertAction) -> Void in
+            //do nothing just close the alert
+        }
+        alertController.addAction(okAction)
+        self.present(alertController, animated: true, completion: nil)
+    }
+    
+    //takes a create channel response and shows alerts if something's wrong. also resets session in progress if there's an error
+    func handleCreateChannelResponse(data: Data?, response: URLResponse?, error: Error?) {
+        if(error != nil) {
+            //make an alert with the error
+            showAlert(alertstring: error!.localizedDescription)
+        }
+        if (response != nil) {
+            //need to do this to have access to the status code
+            let httpresponse = response as! HTTPURLResponse
+            //take the status code and show an alert if needed
+            let alert = handleCreateChannelResponseCode(statuscode: httpresponse.statusCode)
+            if (alert != nil) {
+                showAlert(alertstring: alert!)
+            }
+        }
+        if (data != nil) {
+            //if there is anything that needs data it can go here
+        }
+    }
+    
+    //takes the status code from the create channel response and interpret it
+    func handleCreateChannelResponseCode(statuscode:Int) -> String? {
+        var message:String? = nil
+        if(statuscode != channelCreateSuccessStatusCode) {
+            if (statuscode == channelCreateFailureStatusCode) {
+                message = "Channel name invalid. There may already be a channel with that name."
+            }
+            else {
+                message = "Status code: " + String(statuscode)
+            }
+        }
+        return message
+    }
+    
+    //MARK: properties
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
     }
-
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-
-
+    
+    //MARK: actions
+    
 }
 

--- a/ios/sound-send/sound-sendTests/sound_sendTests.swift
+++ b/ios/sound-send/sound-sendTests/sound_sendTests.swift
@@ -11,9 +11,13 @@ import XCTest
 
 class sound_sendTests: XCTestCase {
     
+    var vc: ViewController!
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
+        let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
+        vc = storyboard.instantiateInitialViewController() as! ViewController
     }
     
     override func tearDown() {
@@ -21,16 +25,17 @@ class sound_sendTests: XCTestCase {
         super.tearDown()
     }
     
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testGenerateCreateChannelURL() {
+        let url = vc.generateCreateChannelURL(channelname: "test")
+        let uuid = UIDevice.current.identifierForVendor!.uuidString
+        XCTAssert(url == (vc.baseurl+vc.createchannelpath+"test/"+uuid))
     }
     
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func testHandleCreateChannelResponseCode() {
+        let goodcode = vc.channelCreateSuccessStatusCode
+        XCTAssert(vc.handleCreateChannelResponseCode(statuscode: goodcode) == nil)
+        let badcode = vc.channelCreateFailureStatusCode
+        XCTAssert(vc.handleCreateChannelResponseCode(statuscode: badcode) != nil)
     }
     
 }


### PR DESCRIPTION
the code is in the sound send  folder, not the sejaladiti one
the code is in ViewController. this makes it easier to get alerts through, since the httprequest is asyncronous

createChannel doesn't have a unit test, because its asynchronous and i don't know how that would work. the entirety of the asynchronous part is in a function, so hopefully its mitigated.
handleCreateChannelResponse also doesn't have a unit test. i'm not sure how to properly test it honestly. much of its output is on the ui.
showAlert is entirely a ui thing
generateCreateChannelURL and handleCreateChannelResponseCode have unit tests

you can test this code by putting createChannel("test") in viewDidLoad. as it is, an alert should pop up and show "Error 200" since someone owns soundsend.com. 201 is what main.py has as the correct code, which is why it shows "error". changing the baseurl to "sound-send.com" pops up a different error, this time from client side, since that domain doesn't exist. with baseurl pointed the right way, no popups should appear and the channel should be created server side. i wasn't able to test this.